### PR TITLE
Switch to djangocms-text and update CKEditor configuration

### DIFF
--- a/core/settings/base.py
+++ b/core/settings/base.py
@@ -48,12 +48,14 @@ THIRD_PARTY_APPS = (
     'filer',
     'easy_thumbnails',
     'mptt',
-    'djangocms_text_ckeditor',
+    # 'djangocms_text_ckeditor',
+    'djangocms_text',
     'djangocms_link',
     'djangocms_file',
     'djangocms_picture',
     'djangocms_snippet',
     'ckeditor',
+    'djangocms_text.contrib.text_ckeditor5',
 )
 
 LOCAL_APPS = (
@@ -62,7 +64,7 @@ LOCAL_APPS = (
 )
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
-
+DJANGOCMS_TEXT_EDITOR = "djangocms_text.contrib.text_ckeditor5.ckeditor5"
 
 # ==============================================================================
 # MIDDLEWARE CONFIGURATION

--- a/core/static/core/css/fix-ckeditor.css
+++ b/core/static/core/css/fix-ckeditor.css
@@ -1,0 +1,14 @@
+.cms-dialog {
+    top: 40% !important;
+    height: 500px;
+}
+
+.cms-dialog .cms-modal-body {
+    position: relative  !important;
+    top: 0  !important;
+    height: 370px ;
+}
+.cms-dialog .cms-modal-body iframe {
+    width: 100%;
+    height: 100%;
+}

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,7 +1,7 @@
 Django==4.2.*
 django-cms==3.11.*
 django-extensions==3.2.*
-django-ckeditor==6.7.1
+#django-ckeditor==6.7.1
 django-classy-tags
 django-treebeard==4.7.*
 django-filer==3.1.*
@@ -12,7 +12,8 @@ djangocms-file==3.0.*
 djangocms-link==3.1.*
 djangocms-picture==4.1.*
 djangocms-snippet==3.1.*
-djangocms-text-ckeditor==5.1.5
+#djangocms-text-ckeditor==5.1.5
+djangocms-text==0.2.*
 easy-thumbnails==2.8.*
 Pillow==10.4.*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==4.2.*
 django-cms==3.11.*
 django-extensions
-django-ckeditor
+#django-ckeditor
 django-classy-tags
 django-treebeard
 django-filer
@@ -12,7 +12,8 @@ djangocms-file
 djangocms-link
 djangocms-picture
 djangocms-snippet
-djangocms-text-ckeditor
+#djangocms-text-ckeditor
+djangocms-text
 easy-thumbnails
 Pillow
 

--- a/templates/ckeditor/widget.html
+++ b/templates/ckeditor/widget.html
@@ -1,0 +1,11 @@
+<div class="ck-editor-container">
+<textarea  name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+{% if widget.value %}{{ widget.value }}{% endif %}</textarea>
+<span class="word-count" id="{{script_id}}-word-count"></span>
+{% if errors %}
+{{ errors }}
+{% endif %}
+</div>
+<input type="hidden" id="{{script_id}}-ck-editor-5-upload-url" data-upload-url="{{upload_url}}" data-upload-file-types="{{upload_file_types}}" data-csrf_cookie_name="{{ csrf_cookie_name }}">
+
+<span id="{{script_id}}-span">{{ config|json_script:script_id }}</span>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -16,8 +16,11 @@
 
 	<!-- /// Template CSS ////////  -->
 	<link rel="stylesheet" href="{% static "core/css/app.css" %}">
-
-	{% render_block "css" %}
+  {% render_block "css" %}
+  {% if request.user.is_staff %}
+	<link rel="stylesheet" href="{% static "core/css/fix-ckeditor.css" %}">
+  {% endif %}
+	
 </head>
 
 


### PR DESCRIPTION
- Replaced `djangocms-text-ckeditor` with `djangocms-text` for better compatibility and performance.
- Updated requirements and settings files accordingly.
- Added custom CSS for CKEditor fixes and a new template for the CKEditor widget.