### PR TITLE
Enhance JSON response and adjust timestamp calculation

### DIFF
--- a/pwn_event/views/n8n.py
+++ b/pwn_event/views/n8n.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from time import mktime
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.http import JsonResponse
 from django.utils.html import strip_tags
@@ -34,10 +34,11 @@ def n8n_json_view(request):
             "description": strip_tags(description)
         }
 
-    return JsonResponse(data)
+    return JsonResponse(data, safe=False, json_dumps_params={'ensure_ascii': False})
 
 
 def get_timestamp(date):
+    date = date + timedelta(hours=2)
     element = datetime.strptime(str(date), '%Y-%m-%d %H:%M:%S%z')
     tuple = element.timetuple()
     timestamp = mktime(tuple)


### PR DESCRIPTION
Modify JSON response to ensure non-ASCII characters are handled properly by setting `ensure_ascii` to False. Additionally, include a 2-hour offset to the timestamp calculation using `timedelta` for more accurate time representation.