### PR TITLE
Fix - ordre d'affichage des confs sur la homepage

### DIFF
--- a/pwn_event/templatetags/pwn_event.py
+++ b/pwn_event/templatetags/pwn_event.py
@@ -36,9 +36,13 @@ def get_last_events(context, number=3, template='pwn_event/template_tags/last_ev
     last_event_time = now().replace(hour=00, minute=00, second=00)
     request = context['request']
     if request.user.is_superuser:
-        events = Event.objects.filter(season=season, date__gte=last_event_time)[:number]
+        events = Event.objects
     else:
-        events = Event.published.filter(season=season, date__gte=last_event_time)[:number]
+        events = Event.published
+
+    events = reversed(events
+              .filter(season=season, date__gte=last_event_time)
+              .order_by('date')[:number])
 
     return {'template': template, 'events': events}
 


### PR DESCRIPTION
L'ordre d'affichage des confs était erroné sur la page d'accueil. 

L'ordre d'affichage a été corrigé pour afficher les 3 prochaines confs à la place des 3 dernières.