### PR TITLE
Display futur season events

### DIFF
--- a/pwn_event/templatetags/pwn_event.py
+++ b/pwn_event/templatetags/pwn_event.py
@@ -42,3 +42,28 @@ def get_last_events(context, number=3, template='pwn_event/template_tags/last_ev
 
     return {'template': template, 'events': events}
 
+
+@register.inclusion_tag('pwn_event/template_tags/dummy.html', takes_context=True)
+def get_futur_season_events(context, number=3, template='pwn_event/template_tags/last_events.html'):
+    """
+    Return the most recent creations.
+    """
+
+    try:
+        season = Season.objects.get(
+                start_date__year=now().year, start_date__month=9
+            )
+    except Season.DoesNotExist:
+        season = None
+    last_event_time = now().replace(hour=00, minute=00, second=00)
+    request = context['request']
+    if request.user.is_superuser:
+        events = Event.objects
+    else:
+        events = Event.published
+
+    events = reversed(events
+              .filter(season=season, date__gte=last_event_time)
+              .order_by('date')[:number])
+
+    return {'template': template, 'events': events}

--- a/pwn_event/views/event.py
+++ b/pwn_event/views/event.py
@@ -43,7 +43,7 @@ class EventBySeasonListView(ListView):
                 start_date__year=now().year, start_date__month=9
             )
             context["futur_events"] = Event.objects.filter(
-                date__year=now().year, date__month__gte=9
+                date__year__gte=now().year, date__month__gte=9
             )
         except Season.DoesNotExist:
             context["futur_season"] = None

--- a/pwn_event/views/event.py
+++ b/pwn_event/views/event.py
@@ -43,7 +43,7 @@ class EventBySeasonListView(ListView):
                 start_date__year=now().year, start_date__month=9
             )
             context["futur_events"] = Event.objects.filter(
-                date__year__gte=now().year, date__month__gte=9
+                season=context["futur_season"]
             )
         except Season.DoesNotExist:
             context["futur_season"] = None

--- a/pwn_event/views/event.py
+++ b/pwn_event/views/event.py
@@ -38,6 +38,16 @@ class EventBySeasonListView(ListView):
     def get_context_data(self, **kwargs):
         context = super(EventBySeasonListView, self).get_context_data(**kwargs)
         context['actual_season'] = self.season
+        try:
+            context["futur_season"] = Season.objects.get(
+                start_date__year=now().year, start_date__month=9
+            )
+            context["futur_events"] = Event.objects.filter(
+                date__year=now().year, date__month__gte=9
+            )
+        except Season.DoesNotExist:
+            context["futur_season"] = None
+            context["futur_events"] = None
 
         try:
             past_seasons = Season.objects.filter(start_date__lte=now())

--- a/templates/home.html
+++ b/templates/home.html
@@ -16,7 +16,8 @@
         <div class="grid event-grid">
           {# {% placeholder "Liste events" %}#}
           {% get_last_events 3 %}
-          
+
+
           <article class="event grid-item col event-suggest">
             <div class="event-inner">
               <a href="/contact" class="link-overlay"></a>
@@ -31,6 +32,15 @@
             </div>
           </article>         
 
+        <div class="clear"></div>
+
+        <h2 class="section-title section-title-centered" style="margin-top: 50px;">
+          <span class="before"></span>
+          <span class="center">Prochaine saison !!</span>
+          <span class="after"></span>
+        </h2>
+        <div class="clear"></div>
+        {% get_futur_season_events 3 %}
         </div>
 
         <div class="align-center">

--- a/templates/home.html
+++ b/templates/home.html
@@ -40,7 +40,7 @@
           <span class="after"></span>
         </h2>
         <div class="clear"></div>
-        {% get_futur_season_events 3 %}
+        {% get_futur_season_events 10 %}
         </div>
 
         <div class="align-center">

--- a/templates/pwn_event/event_season_list.html
+++ b/templates/pwn_event/event_season_list.html
@@ -25,25 +25,25 @@
     <div class="clear"></div>
 
     {# --- ÉVÉNEMENTS PROCHAINE SAISON --- #}
-    {% if futur_season %}
-    <h2 class="section-title section-title-centered">
-      <span class="before"></span>
-      <span class="center">Prochaine saison !!</span>
-      <span class="after"></span>
-    </h2>
-
-    <div class="clear"></div>
-
-    <div class="upcoming-events grid event-grid">
-        {% for event in futur_events reversed%}
-            {% include "pwn_event/includes/event_list_item.html" %}
-        {% empty %}
-            <p>Pas d'événement pour le moment :(</p>
-        {% endfor %}
-    </div>
-
-    <div class="clear"></div>
-    {% endif %}
+{#    {% if futur_season %}#}
+{#    <h2 class="section-title section-title-centered">#}
+{#      <span class="before"></span>#}
+{#      <span class="center">Prochaine saison !!</span>#}
+{#      <span class="after"></span>#}
+{#    </h2>#}
+{##}
+{#    <div class="clear"></div>#}
+{##}
+{#    <div class="upcoming-events grid event-grid">#}
+{#        {% for event in futur_events reversed%}#}
+{#            {% include "pwn_event/includes/event_list_item.html" %}#}
+{#        {% empty %}#}
+{#            <p>Pas d'événement pour le moment :(</p>#}
+{#        {% endfor %}#}
+{#    </div>#}
+{##}
+{#    <div class="clear"></div>#}
+{#    {% endif %}#}
 
     {# --- ÉVÉNEMENTS PASSÉS --- #}
     <h2 class="section-title section-title-centered">

--- a/templates/pwn_event/event_season_list.html
+++ b/templates/pwn_event/event_season_list.html
@@ -25,25 +25,25 @@
     <div class="clear"></div>
 
     {# --- ÉVÉNEMENTS PROCHAINE SAISON --- #}
-{#    {% if futur_season %}#}
-{#    <h2 class="section-title section-title-centered">#}
-{#      <span class="before"></span>#}
-{#      <span class="center">Prochaine saison !!</span>#}
-{#      <span class="after"></span>#}
-{#    </h2>#}
-{##}
-{#    <div class="clear"></div>#}
-{##}
-{#    <div class="upcoming-events grid event-grid">#}
-{#        {% for event in futur_events reversed%}#}
-{#            {% include "pwn_event/includes/event_list_item.html" %}#}
-{#        {% empty %}#}
-{#            <p>Pas d'événement pour le moment :(</p>#}
-{#        {% endfor %}#}
-{#    </div>#}
-{##}
-{#    <div class="clear"></div>#}
-{#    {% endif %}#}
+    {% if futur_season %}
+    <h2 class="section-title section-title-centered">
+      <span class="before"></span>
+      <span class="center">Prochaine saison !!</span>
+      <span class="after"></span>
+    </h2>
+
+    <div class="clear"></div>
+
+    <div class="upcoming-events grid event-grid">
+        {% for event in futur_events reversed%}
+            {% include "pwn_event/includes/event_list_item.html" %}
+        {% empty %}
+            <p>Pas d'événement pour le moment :(</p>
+        {% endfor %}
+    </div>
+
+    <div class="clear"></div>
+    {% endif %}
 
     {# --- ÉVÉNEMENTS PASSÉS --- #}
     <h2 class="section-title section-title-centered">

--- a/templates/pwn_event/event_season_list.html
+++ b/templates/pwn_event/event_season_list.html
@@ -8,14 +8,14 @@
     {# --- ÉVÉNEMENTS À VENIR --- #}
     <h2 class="section-title section-title-centered">
       <span class="before"></span>
-      <span class="center">liste des événements à venir</span>
+      <span class="center">événements à venir</span>
       <span class="after"></span>
     </h2>
 
     <div class="clear"></div>
     
     <div class="upcoming-events grid event-grid">
-        {% for event in events reversed%}
+        {% for event in events reversed %}
             {% include "pwn_event/includes/event_list_item.html" %}
         {% empty %}
             <p>Pas d'événement pour le moment :(</p>
@@ -24,11 +24,31 @@
     
     <div class="clear"></div>
 
+    {# --- ÉVÉNEMENTS PROCHAINE SAISON --- #}
+    {% if futur_season %}
+    <h2 class="section-title section-title-centered">
+      <span class="before"></span>
+      <span class="center">Prochaine saison !!</span>
+      <span class="after"></span>
+    </h2>
+
+    <div class="clear"></div>
+
+    <div class="upcoming-events grid event-grid">
+        {% for event in futur_events reversed%}
+            {% include "pwn_event/includes/event_list_item.html" %}
+        {% empty %}
+            <p>Pas d'événement pour le moment :(</p>
+        {% endfor %}
+    </div>
+
+    <div class="clear"></div>
+    {% endif %}
 
     {# --- ÉVÉNEMENTS PASSÉS --- #}
     <h2 class="section-title section-title-centered">
       <span class="before"></span>
-      <span class="center">liste des événements passés</span>
+      <span class="center">événements passés</span>
       <span class="after"></span>
     </h2>
 


### PR DESCRIPTION
# Description

Nous souhaitons afficher les événements des futurs saisons. Pour le moment, seules les événements d'une saison en cours s'affichent.

# Proposition

- [x] ajouter un `templatetag` permettant d'afficher tous les événements de la prochaine saison
- [x] utilisation du `templatetag` dans les templates de la page d'accueil et de la page listant tous les événements.